### PR TITLE
added legacy support change and submit events in ie 6/7/8

### DIFF
--- a/plugins/gator-legacy.js
+++ b/plugins/gator-legacy.js
@@ -27,8 +27,27 @@
             type = 'focusout';
         }
 
+        if (type == 'change') {
+            gator.element.attachEvent('onfocusin', function(){
+                _legacyAttach(type, window.event.srcElement, callback)
+            });
+        }
+
+        if (type == 'submit') {
+            gator.element.attachEvent('onfocusin', function(){
+                _legacyAttach(type, window.event.srcElement.form, callback)
+            });
+        }
+
         gator.element.attachEvent('on' + type, callback);
     };
+
+    function _legacyAttach(type, element, callback) {
+        if(element && !element.getAttribute('data-gator-attached')) {
+            element.attachEvent('on' + type, callback);
+            element.setAttribute('data-gator-attached','true');
+        }
+    }
 
     Gator.matchesSelector = function(selector) {
 


### PR DESCRIPTION
This is a simple fix for issue #7. It adds support for change and submit events in legacy ie browsers which don't support event bubbling on them. It uses a simple trick by catching the first focus event on the element and then attaching the callback to the correct event.
