### PR TITLE
Use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "delegation"
   ],
   "author": "Craig Campbell",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ccampbell/gator/issues"
   },


### PR DESCRIPTION
"Apache 2" is not a valid SPDX license identifier