### PR TITLE
Handle empty events array

### DIFF
--- a/gator.js
+++ b/gator.js
@@ -184,7 +184,7 @@
         // if we have specified an event type, selector, and callback then we
         // need to make sure there are callbacks tied to this selector to
         // begin with.  if there aren't then we can stop here
-        if (!_handlers[gator.id][event][selector]) {
+        if (!_handlers[gator.id][event] || !_handlers[gator.id][event][selector]) {
             return;
         }
 


### PR DESCRIPTION
It's common to pre-emptively call `off` with an event and handler prior
to any handlers being registered. This is a safeguard to ensure that the
same handler isn't attached multiple times. In this scenario, the events
array isn't checked for existence prior to the accessor call (for the
given selector). Thus a TypeError is raised.

Closes #31